### PR TITLE
Remove fromScript option

### DIFF
--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommits.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommits.scala
@@ -8,23 +8,20 @@ import scala.util.Using
 
 import better.files.Dsl._
 import better.files._
-import sbt.URL
 
 object ConventionalCommits {
-  def apply(baseDir: JFile, fromScript: Option[URL]): Unit = conventionalCommitsTask(baseDir, fromScript)
+  def apply(baseDir: JFile): Unit = conventionalCommitsTask(baseDir)
 
-  private def conventionalCommitsTask(baseDir: JFile, fromScript: Option[URL]): Unit = {
+  private def conventionalCommitsTask(baseDir: JFile): Unit = {
     getGitRoot(baseDir.toScala).map(_ / "hooks" / "commit-msg") match {
-      case Some(path) => writeScript(path, fromScript)
+      case Some(path) => writeScript(path)
       case None => throw new IllegalStateException("Unable to find git root")
     }
   }
 
-  private def writeScript(file: File, fromScript: Option[URL]): Unit = {
-    val fileContent = fromScript match {
-      case Some(url) => Using(Source.fromURL(url)) { _.mkString }.get
-      case None => Using(Source.fromInputStream(getClass.getResourceAsStream("/commit-msg.sh"))) { _.mkString }.get
-    }
+  private def writeScript(file: File): Unit = {
+    val fileContent =
+      Using(Source.fromInputStream(getClass.getResourceAsStream("/commit-msg.sh"))) { _.mkString }.get
     file < fileContent
     chmod_+(PosixFilePermission.OWNER_EXECUTE, file)
   }

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsKeys.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsKeys.scala
@@ -3,6 +3,5 @@ package it.nicolasfarabegoli
 import sbt._
 
 trait ConventionalCommitsKeys {
-  val fromScript = settingKey[Option[URL]]("Specify a remote URL for custom script")
   val conventionalCommits = taskKey[Unit]("Task for creating a git hook for enforcing conventional commits")
 }

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
@@ -11,10 +11,9 @@ object ConventionalCommitsPlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val globalSettings: Seq[Setting[_]] = Seq(
-    fromScript := None,
   )
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    conventionalCommits := ConventionalCommits(baseDirectory.value, fromScript.value),
+    conventionalCommits := ConventionalCommits(baseDirectory.value),
   )
 }

--- a/src/sbt-test/sbt-cc/remote/build.sbt
+++ b/src/sbt-test/sbt-cc/remote/build.sbt
@@ -1,9 +1,0 @@
-lazy val root = project
-  .in(file("."))
-  .settings(
-    fromScript := Some(
-      url(
-        "https://gist.githubusercontent.com/nicolasfara/731bfe58dc5f3bc40387782d9091b519/raw/18398c29144317b9657c131f3d72ff4d24e0122c/commit-msg",
-      ),
-    ),
-  )

--- a/src/sbt-test/sbt-cc/remote/project/plugins.sbt
+++ b/src/sbt-test/sbt-cc/remote/project/plugins.sbt
@@ -1,4 +1,0 @@
-sys.props.get("plugin.version") match {
-  case Some(v) => addSbtPlugin("it.nicolasfarabegoli" % "sbt-conventional-commits" % v)
-  case _ => sys.error("No version specified")
-}

--- a/src/sbt-test/sbt-cc/remote/test
+++ b/src/sbt-test/sbt-cc/remote/test
@@ -1,4 +1,0 @@
-$ mkdir .git/hooks
-> conventionalCommits
-$ exists .git/hooks/commit-msg
-$ exec ./test.sh

--- a/src/sbt-test/sbt-cc/remote/test.sh
+++ b/src/sbt-test/sbt-cc/remote/test.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-[[ -x .git/hooks/commit-msg ]]


### PR DESCRIPTION
For security reasons it may be better to avoid downloading an arbitrary script. This PR removes that option.