### PR TITLE
Add customization of types and scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,18 @@ More details at: https://www.conventionalcommits.org/en/v1.0.0/#summary
 > git commit -m "feat: we love conventional commit!"
 Conventional Commit standards...
 ```
+
+You can configure the available types for your commits by setting the `ThisBuild / conventionalCommits / types` key.
+The default commit types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, and `test`. 
+```scala
+ThisBuild / conventionalCommits / types := Seq("feat", "fix") // Allow only feat and fix commits
+ThisBuild / conventionalCommits / types ++= Seq("some", "other") // Allow "some" and "other" in addition to the default types
+```
+
+In the same way, you can restrict the available scopes by setting the `ThisBuild / conventionalCommits / scopes` key.
+By default, all scopes are allowed.
+
+```scala
+ThisBuild / conventionalCommits / scopes := Seq() // Allow all scopes
+ThisBuild / conventionalCommits / scopes := Seq("scope1", "scope2") // Allow only scope1 and scope2
+```

--- a/src/main/resources/commit-msg.sh
+++ b/src/main/resources/commit-msg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Create a regex for a conventional commit.
-conventional_commit_regex="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z \-]+\))?!?: .+$"
+conventional_commit_regex="^(%s)(\(%s\))?!?: .+$"
 
 # Get the commit message (the parameter we're given is just the path to the
 # temporary file which holds the message).

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsKeys.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsKeys.scala
@@ -4,4 +4,6 @@ import sbt._
 
 trait ConventionalCommitsKeys {
   val conventionalCommits = taskKey[Unit]("Task for creating a git hook for enforcing conventional commits")
+  val scopes = settingKey[Seq[String]]("A list of valid scopes (defaults to any)")
+  val types = settingKey[Seq[String]]("A list of valid commit types")
 }

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
@@ -10,10 +10,7 @@ object ConventionalCommitsPlugin extends AutoPlugin {
   object autoImport extends ConventionalCommitsKeys
   import autoImport._
 
-  override lazy val globalSettings: Seq[Setting[_]] = Seq(
-  )
-
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+  override lazy val buildSettings: Seq[Setting[_]] = Seq(
     conventionalCommits := ConventionalCommits(baseDirectory.value),
   )
 }

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
@@ -11,6 +11,24 @@ object ConventionalCommitsPlugin extends AutoPlugin {
   import autoImport._
 
   override lazy val buildSettings: Seq[Setting[_]] = Seq(
-    conventionalCommits := ConventionalCommits(baseDirectory.value),
+    conventionalCommits / types := Seq(
+      "build",
+      "chore",
+      "ci",
+      "docs",
+      "feat",
+      "fix",
+      "perf",
+      "refactor",
+      "revert",
+      "style",
+      "test",
+    ),
+    conventionalCommits / scopes := Seq(),
+    conventionalCommits := ConventionalCommits(
+      baseDirectory.value,
+      (conventionalCommits / types).value,
+      (conventionalCommits / scopes).value,
+    ),
   )
 }

--- a/src/sbt-test/sbt-cc/default-script/build.sbt
+++ b/src/sbt-test/sbt-cc/default-script/build.sbt
@@ -1,0 +1,16 @@
+import scala.io.Source
+import scala.util.Using
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    TaskKey[Unit]("check") := {
+      val expectedRegex = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z \\-]+\\))?!?: .+$"
+      Using(Source.fromFile(".git/hooks/commit-msg")) { file =>
+        val lines = file.getLines()
+        val foundRegex = lines.exists(_ contains expectedRegex)
+        if (!foundRegex) sys.error(s"The expected regex was not found.\nFile contents:\n${file.mkString}")
+        ()
+      }
+    },
+  )

--- a/src/sbt-test/sbt-cc/default-script/project/plugins.sbt
+++ b/src/sbt-test/sbt-cc/default-script/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("it.nicolasfarabegoli" % "sbt-conventional-commits" % v)
+  case _ => sys.error("No version specified")
+}

--- a/src/sbt-test/sbt-cc/default-script/test
+++ b/src/sbt-test/sbt-cc/default-script/test
@@ -1,0 +1,3 @@
+$ mkdir .git/hooks
+> conventionalCommits
+> check

--- a/src/sbt-test/sbt-cc/selected-scopes/build.sbt
+++ b/src/sbt-test/sbt-cc/selected-scopes/build.sbt
@@ -1,0 +1,18 @@
+import scala.io.Source
+import scala.util.Using
+
+ThisBuild / conventionalCommits / scopes := Seq("abc", "cde")
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    TaskKey[Unit]("check") := {
+      val expectedRegex = "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(abc|cde\\))?!?: .+$"
+      Using(Source.fromFile(".git/hooks/commit-msg")) { file =>
+        val lines = file.getLines()
+        val foundRegex = lines.exists(_ contains expectedRegex)
+        if (!foundRegex) sys.error(s"The expected regex was not found.\nFile contents:\n${file.mkString}")
+        ()
+      }
+    },
+  )

--- a/src/sbt-test/sbt-cc/selected-scopes/project/plugins.sbt
+++ b/src/sbt-test/sbt-cc/selected-scopes/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("it.nicolasfarabegoli" % "sbt-conventional-commits" % v)
+  case _ => sys.error("No version specified")
+}

--- a/src/sbt-test/sbt-cc/selected-scopes/test
+++ b/src/sbt-test/sbt-cc/selected-scopes/test
@@ -1,0 +1,3 @@
+$ mkdir .git/hooks
+> conventionalCommits
+> check

--- a/src/sbt-test/sbt-cc/selected-types/build.sbt
+++ b/src/sbt-test/sbt-cc/selected-types/build.sbt
@@ -1,0 +1,18 @@
+import scala.io.Source
+import scala.util.Using
+
+ThisBuild / conventionalCommits / types := Seq("fix", "feat")
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    TaskKey[Unit]("check") := {
+      val expectedRegex = "^(fix|feat)(\\([a-z \\-]+\\))?!?: .+$"
+      Using(Source.fromFile(".git/hooks/commit-msg")) { file =>
+        val lines = file.getLines()
+        val foundRegex = lines.exists(_ contains expectedRegex)
+        if (!foundRegex) sys.error(s"The expected regex was not found.\nFile contents:\n${file.mkString}")
+        ()
+      }
+    },
+  )

--- a/src/sbt-test/sbt-cc/selected-types/project/plugins.sbt
+++ b/src/sbt-test/sbt-cc/selected-types/project/plugins.sbt
@@ -1,0 +1,4 @@
+sys.props.get("plugin.version") match {
+  case Some(v) => addSbtPlugin("it.nicolasfarabegoli" % "sbt-conventional-commits" % v)
+  case _ => sys.error("No version specified")
+}

--- a/src/sbt-test/sbt-cc/selected-types/test
+++ b/src/sbt-test/sbt-cc/selected-types/test
@@ -1,0 +1,3 @@
+$ mkdir .git/hooks
+> conventionalCommits
+> check


### PR DESCRIPTION
This PR allows the user to customize types and scopes for their commits.

Closes #13 