### PR TITLE
Fix newline and single quotes escaping issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-conventional-commits",
-    version := "2.2.0",
+    version := "2.2.1-SNAPSHOT",
     sbtPlugin := true,
     publishTo := sonatypePublishToBundle.value,
     sonatypeCredentialHost := "s01.oss.sonatype.org",

--- a/src/main/scala/it/nicolasfarabegoli/CommitMessageScript.scala
+++ b/src/main/scala/it/nicolasfarabegoli/CommitMessageScript.scala
@@ -31,8 +31,10 @@ object CommitMessageScript {
       |# Uh-oh, this is not a conventional commit, show an example and link to the spec.
       |$failureMessageEcho
       |exit 1
-      |""".stripMargin
+      |""".stripMargin.stripLeading
   }
 
-  private def wrapInEcho(str: Option[String]): String = str map { s => s"echo -e '$s'" } getOrElse ""
+  private def wrapInEcho(str: Option[String]): String = str map { s => s"echo -e '${escape(s)}'" } getOrElse ""
+
+  private def escape(str: String): String = str.replace("\r", "").replace("\n", "\\n").replace("'", "\\'")
 }

--- a/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
+++ b/src/main/scala/it/nicolasfarabegoli/ConventionalCommitsPlugin.scala
@@ -18,7 +18,7 @@ object ConventionalCommitsPlugin extends AutoPlugin {
       |An example of a valid message is: 
       |  feat(login): add the 'remember me' button
       |More details at: https://www.conventionalcommits.org/en/v1.0.0/#summary
-      |""".stripMargin
+      |""".stripMargin.strip
 
   override lazy val buildSettings: Seq[Setting[_]] = Seq(
     conventionalCommits / types := Seq(


### PR DESCRIPTION
This PR fixes an unintended behavior that results in a malformed script, with a newline on top of the shebang and with the messages not correctly being escaped.