### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,7 +4,7 @@ plugins:
     - preset: conventionalcommits
   - '@semantic-release/release-notes-generator'
   - '@semantic-release/changelog'
-  - - '@google/semantic-release-replace-plugin'
+  - - 'semantic-release-replace-plugin'
     - replacements:
         - files:
             - build.sbt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "sbt-conventional-commits",
+  "name": "nicolasfara_sbt-conventional-commits",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
-        "@google/semantic-release-replace-plugin": "1.2.5",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "conventional-changelog-conventionalcommits": "6.1.0",
-        "gradle-semantic-release-plugin": "1.7.6"
+        "gradle-semantic-release-plugin": "1.7.6",
+        "semantic-release-replace-plugin": "1.2.6"
       },
       "engines": {
         "node": "18.16"
@@ -122,18 +122,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@google/semantic-release-replace-plugin": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@google/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.5.tgz",
-      "integrity": "sha512-msiG7WnwRjXz+y44OWDulVoaKfuEHksbRljD5PE+NVeujfNfN2D31j/sluNNAjTH6nm+p2ppYnZDl6jLPBikCA==",
-      "deprecated": "This package has been renamed to semantic-release-replace-plugin.",
-      "dev": true,
-      "dependencies": {
-        "jest-diff": "^29.6.0",
-        "lodash-es": "^4.17.21",
-        "replace-in-file": "^7.0.1"
       }
     },
     "node_modules/@jest/schemas": {
@@ -6025,6 +6013,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/semantic-release-replace-plugin": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.6.tgz",
+      "integrity": "sha512-/0aRwQ3taocrfIOYQ94IQHVUYJXyVGkhJCBNp2dagE4KKghGPMWKGaisvxveJV28X4V9PogxCvHdTd+Rrz8kxw==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^29.6.0",
+        "lodash-es": "^4.17.21",
+        "replace-in-file": "^7.0.1"
+      }
+    },
     "node_modules/semantic-release/node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -7172,17 +7171,6 @@
       "dev": true,
       "optional": true,
       "peer": true
-    },
-    "@google/semantic-release-replace-plugin": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@google/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.5.tgz",
-      "integrity": "sha512-msiG7WnwRjXz+y44OWDulVoaKfuEHksbRljD5PE+NVeujfNfN2D31j/sluNNAjTH6nm+p2ppYnZDl6jLPBikCA==",
-      "dev": true,
-      "requires": {
-        "jest-diff": "^29.6.0",
-        "lodash-es": "^4.17.21",
-        "replace-in-file": "^7.0.1"
-      }
     },
     "@jest/schemas": {
       "version": "29.6.0",
@@ -11790,6 +11778,17 @@
           "dev": true,
           "peer": true
         }
+      }
+    },
+    "semantic-release-replace-plugin": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/semantic-release-replace-plugin/-/semantic-release-replace-plugin-1.2.6.tgz",
+      "integrity": "sha512-/0aRwQ3taocrfIOYQ94IQHVUYJXyVGkhJCBNp2dagE4KKghGPMWKGaisvxveJV28X4V9PogxCvHdTd+Rrz8kxw==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^29.6.0",
+        "lodash-es": "^4.17.21",
+        "replace-in-file": "^7.0.1"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@semantic-release/git": "10.0.1",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "gradle-semantic-release-plugin": "1.7.6",
-    "@google/semantic-release-replace-plugin": "1.2.5"
+    "semantic-release-replace-plugin": "1.2.6"
   },
   "engines": {
     "node": "18.16"


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).